### PR TITLE
Open Caffe model file in binary mode

### DIFF
--- a/convert_caffe2tf.py
+++ b/convert_caffe2tf.py
@@ -17,7 +17,7 @@ args = parser.parse_args()
 
 caffe_weights = {}
 
-with open(args.input_model, 'r') as fp:
+with open(args.input_model, 'rb') as fp:
     net = NetParameter()
     net.ParseFromString(fp.read())
     #text_format.Merge(fp.read(), net)


### PR DESCRIPTION
On Windows, the fp.read() command below this line will fail if the model file is not opened in binary mode